### PR TITLE
Output LLM responses as a stream

### DIFF
--- a/cli/cli.py
+++ b/cli/cli.py
@@ -2,6 +2,7 @@ from prompt_toolkit import PromptSession
 from prompt_toolkit.styles import Style
 from rich.console import Console
 from rich.markdown import Markdown
+from rich.live import Live
 import cli.heading_override
 import os
 
@@ -110,14 +111,19 @@ class CLI:
 
     def respond(self):
         print(f"{BOLD}Path {self.path_index} Assistant: {RESET}")
-        full_response = ""
-        for message_chunk in self.crossroads.get_response(self.paths[self.path_index]):
-            print(message_chunk, end="", flush=True)
-            full_response += message_chunk
-        #self.rich_console.print(Markdown(assistant_response))
-        print("\n")
 
-        return full_response
+        accumulated_markdown = ""
+
+        with Live(console=self.rich_console, refresh_per_second=60) as live:
+            for message_chunk in self.crossroads.get_response(self.paths[self.path_index]):
+                accumulated_markdown += f"{message_chunk}"
+                markdown = Markdown(accumulated_markdown)
+                
+                live.update(markdown)
+
+        print()
+
+        return accumulated_markdown
 
     def run(self):
         while True:

--- a/cli/cli.py
+++ b/cli/cli.py
@@ -14,6 +14,7 @@ class CLI:
         
         self.crossroads = crossroads
         self.session = PromptSession()
+        self.rich_console = Console()
 
         self.paths = [[{"role": "system", "content": "You are a helpful assistant."}], [{"role": "system", "content": "You are a helpful assistant that loves starting words with the letter 'b'."}]]
         self.path_index = 0
@@ -107,9 +108,18 @@ class CLI:
         else:
             print(f"{BOLD+RED}Error:{RESET} Unknown command \"{command}\"")
 
+    def respond(self):
+        print(f"{BOLD}Path {self.path_index} Assistant: {RESET}")
+        full_response = ""
+        for message_chunk in self.crossroads.get_response(self.paths[self.path_index]):
+            print(message_chunk, end="", flush=True)
+            full_response += message_chunk
+        #self.rich_console.print(Markdown(assistant_response))
+        print("\n")
+
+        return full_response
+
     def run(self):
-        rich_console = Console()
-        
         while True:
             try:
                 user_input = self.session.prompt(f"Path {self.path_index} Time {self.timestamp} Prompt: ", style=Style.from_dict({'prompt': 'bold green'}))
@@ -120,11 +130,7 @@ class CLI:
                     print()
                 else:
                     self.paths[self.path_index].append({"role": "user", "content": user_input})
-
-                    assistant_response = self.crossroads.get_response(self.paths[self.path_index])
-                    print(f"{BOLD}Path {self.path_index} Assistant: {RESET}")
-                    rich_console.print(Markdown(assistant_response))
-                    print()
+                    assistant_response = self.respond()
                     self.paths[self.path_index].append({"role": "assistant", "content": assistant_response})
 
                     self.timestamp += 1

--- a/lib/crossroads.py
+++ b/lib/crossroads.py
@@ -10,12 +10,20 @@ class OpenAIHandle:
         self.client = openai.OpenAI()
     
     def get_response(self, messages):
+        """
+        get the response of the LLM as a stream
+        """
         response = self.client.chat.completions.create(
-            model="gpt-4o-mini",
-            messages=messages
+            model='gpt-4o-mini',
+            messages=messages,
+            stream=True
         )
-        return response.choices[0].message.content       
-        
+
+        for chunk in response:
+            message_chunk = chunk.choices[0].delta.content
+            if message_chunk is not None:
+                yield message_chunk
+
 class Crossroads:
     def __init__(self):
         self.openai_handle = OpenAIHandle()


### PR DESCRIPTION
Instead of waiting for ChatGPT to finish generating its response before displaying it, use the `stream=True` flag in the API to retrieve chunks of output as it gets generated.

- [x] proof of concept with no markdown
- [x] proof of concept with markdown
- [x] completed version optimized with markdown

different markdown solutions:
* run the parser on the entire output each time a new chunk gets generated - ~naive solution, very slow~ nevermind, rich is surprisingly very fast; no noticeable slowdown even with running the parser every chunk
* run the parser only every line, on only the line
  * might look weird to user (why generating every line?)
  * will the parser handle lists well?